### PR TITLE
Display MOSS report

### DIFF
--- a/app/lib/moss/mosspy/download_report.py
+++ b/app/lib/moss/mosspy/download_report.py
@@ -13,7 +13,7 @@ def process_url(url, urls, base_url, path, on_read):
     response = urlopen(url)
     html = response.read()
     on_read(url)
-    soup = BeautifulSoup(html, 'lxml')
+    soup = BeautifulSoup(html, 'html.parser')
     file_name = os.path.basename(url)
 
     if not file_name or len(file_name.split(".")) == 1: # Not file name eg. 123456789 or is None

--- a/app/main-process/helloWorld.js
+++ b/app/main-process/helloWorld.js
@@ -8,8 +8,8 @@ export function helloWorld(mainWindowRef, protocolHandler) {
 
 function openHelloWorldWindow(mainWindow, protocolHandler) {
   authWindow = new BrowserWindow({
-    height: 200,
-    width: 400,
+    height: 720,
+    width: 1280,
     show: false,
     parent: mainWindow,
     webPreferences: {
@@ -18,24 +18,8 @@ function openHelloWorldWindow(mainWindow, protocolHandler) {
     },
   })
 
-  authWindow.webContents.loadURL("data:text/html;charset=utf-8,<html>\n" +
-        "\n" +
-        "<head>\n" +
-        "<meta charset=\"UTF-8\" />\n" +
-        "    <title>Hello World</title>\n" +
-        "</head>\n" +
-        "\n" +
-        "<body>\n" +
-        "<div id=\"app\">\n" +
-        "    <h1>Hello World!</h1>\n" +
-        "</div>\n" +
-        "<div>\n" +
-        "    <button type=\"button\"\n" +
-        "            onclick=\"window.close()\">Close</button>\n" +
-        "</div>\n" +
-        "</body>\n" +
-        "\n" +
-        "</html>")
+  const fs = require("fs")
+  authWindow.webContents.loadURL("data:text/html;charset=utf-8," + fs.readFileSync("submission/report.html"))
   authWindow.once("ready-to-show", () => {
     if (authWindow) {
       authWindow.show()


### PR DESCRIPTION
The button after the login screen now displays the contents of submission/report.html when clicked. For now, the submission/report.html file has to be manually copied into the application directory because MOSS is not integrated yet.

The parser was changed from lxml to html.parser because lxml was causing issues on Windows.